### PR TITLE
Remove trailing entry from gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,5 +32,3 @@ MANIFEST
 .env.development
 .env.test
 .env.production
-
-#


### PR DESCRIPTION
## Summary
- remove an unnecessary trailing `#` entry from `.gitignore`
- ensure the file ends without an extra blank line

## Testing
- `git show --stat`

------
https://chatgpt.com/codex/tasks/task_e_68438989ab208326aec97553121ae769