### PR TITLE
Fix user agent configuration

### DIFF
--- a/main.py
+++ b/main.py
@@ -19,8 +19,17 @@ USER_AGENTS = [
 ]
 
 def load_settings():
+    """Load configuration and override defaults if applicable."""
     with open("settings.yaml", "r") as f:
-        return yaml.safe_load(f)
+        config = yaml.safe_load(f)
+
+    # Allow overriding USER_AGENTS from the settings file
+    agents = config.get("user_agents", {}).get("agents")
+    if isinstance(agents, list) and agents:
+        global USER_AGENTS
+        USER_AGENTS = agents
+
+    return config
 
 def check_url(url, headers):
     try:

--- a/settings.yaml
+++ b/settings.yaml
@@ -3,4 +3,8 @@ range:
   country: US
 
 user_agents:
-  agents: ""
+  agents:
+    - "Mozilla/5.0 (Windows NT 10.0)"
+    - "Mozilla/5.0 (X11; Linux x86_64)"
+    - "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)"
+    - "curl/7.68.0"


### PR DESCRIPTION
## Summary
- allow overriding User-Agent list via `settings.yaml`
- provide default user agents in settings file

## Testing
- `python -m py_compile main.py`
- `python main.py` *(fails: ModuleNotFoundError: No module named 'requests')*
- `python -m pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement certifi==2025.4.26)*

------
https://chatgpt.com/codex/tasks/task_e_6843880c01c08326b7a4d684e4b097f1