### PR TITLE
Fix IP network parsing

### DIFF
--- a/main.py
+++ b/main.py
@@ -81,7 +81,8 @@ def main():
     cidr = config["range"]["scan_range"]
     country = config["range"]["country"]
 
-    network = ip_network(cidr)
+    # Allow CIDR ranges that are not aligned to network boundaries
+    network = ip_network(cidr, strict=False)
 
     filename_id = uuid.uuid4().hex[:8]
     output_dir = "results"


### PR DESCRIPTION
## Summary
- allow non-aligned CIDR ranges when scanning

## Testing
- `python - <<'EOF'
from ipaddress import ip_network
print(ip_network('2.16.30.0/22', strict=False))
EOF`

------
https://chatgpt.com/codex/tasks/task_e_684395ac6e94832689c1fc6ef36c6c51