### PR TITLE
Fix unused country setting

### DIFF
--- a/main.py
+++ b/main.py
@@ -79,7 +79,6 @@ def scan_ip(ip, agents=None):
 def main():
     config = load_settings()
     cidr = config["range"]["scan_range"]
-    country = config["range"]["country"]
 
     # Allow CIDR ranges that are not aligned to network boundaries
     network = ip_network(cidr, strict=False)

--- a/settings.example.yaml
+++ b/settings.example.yaml
@@ -1,6 +1,5 @@
 range:
   scan_range: 1.232.49.0/24
-  country: US
 
 user_agents:
   agents:


### PR DESCRIPTION
## Summary
- remove unused `country` config variable from code and settings example

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_6843981ebc948326b71bdefd2d2d225c