### PR TITLE
Add error handling for URL checks

### DIFF
--- a/main.py
+++ b/main.py
@@ -52,6 +52,12 @@ def check_url(url, headers):
         elapsed = int((time.time() - start) * 1000)  # ms
         if r.status_code < 500:
             return r.status_code, elapsed
+    except requests.exceptions.Timeout:
+        return "timeout", None
+    except requests.exceptions.SSLError:
+        return "ssl_error", None
+    except requests.exceptions.TooManyRedirects:
+        return "redirect_loop", None
     except requests.RequestException:
         pass
     return None, None
@@ -81,32 +87,42 @@ def scan_ip(ip, agents=None):
     headers = {"User-Agent": random.choice(agents)}
     http_info = None
     https_info = None
+    http_error = None
+    https_error = None
 
     url_http = f"http://{ip}"
     code, latency = check_url(url_http, headers)
-    if code:
+    if isinstance(code, int):
         print(f"[+] HTTP ответ от {ip}: {code} ({latency}ms)")
         http_info = {
             "port": 80,
             "code": code,
             "latency_ms": latency,
         }
+    elif code:
+        print(f"[!] HTTP ошибка для {ip}: {code}")
+        http_error = code
 
     url_https = f"https://{ip}"
     code, latency = check_url(url_https, headers)
-    if code:
+    if isinstance(code, int):
         print(f"[+] HTTPS ответ от {ip}: {code} ({latency}ms)")
         https_info = {
             "port": 443,
             "code": code,
             "latency_ms": latency,
         }
+    elif code:
+        print(f"[!] HTTPS ошибка для {ip}: {code}")
+        https_error = code
 
-    if http_info or https_info:
+    if http_info or https_info or http_error or https_error:
         return {
             "ip": ip,
             "http": http_info,
             "https": https_info,
+            "http_error": http_error,
+            "https_error": https_error,
         }
     return None
 
@@ -137,6 +153,8 @@ def main():
                 "http_latency_ms",
                 "https_code",
                 "https_latency_ms",
+                "http_error",
+                "https_error",
             ],
         )
         csv_writer.writeheader()
@@ -156,6 +174,8 @@ def main():
                         "http_latency_ms": (entry.get("http") or {}).get("latency_ms", ""),
                         "https_code": (entry.get("https") or {}).get("code", ""),
                         "https_latency_ms": (entry.get("https") or {}).get("latency_ms", ""),
+                        "http_error": entry.get("http_error", ""),
+                        "https_error": entry.get("https_error", ""),
                     })
 
                     if not first:


### PR DESCRIPTION
## Summary
- handle network errors in `check_url`
- record HTTP/HTTPS errors for each IP in `scan_ip`
- include error columns in CSV export

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_68458a22fe7483269f6f1f7a7d10c6cc