### PR TITLE
Add multi-range scanning support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,16 +10,25 @@
    ```
 2. Copy `settings.example.yaml` to `settings.yaml` and adjust the values to your environment.
 
-### scan_range examples
+### scan_ranges examples
 - CIDR notation:
   ```yaml
   range:
-    scan_range: 2.16.37.0/24
+    scan_ranges:
+      - 2.16.37.0/24
   ```
 - Start/End pair:
   ```yaml
   range:
-    scan_range: "2.16.37.0 2.16.37.255"
+    scan_ranges:
+      - "2.16.37.0 2.16.37.255"
+  ```
+- Multiple ranges:
+  ```yaml
+  range:
+    scan_ranges:
+      - 2.16.37.0/24
+      - "2.16.37.0 2.16.37.255"
   ```
 
 ## Usage

--- a/settings.example.yaml
+++ b/settings.example.yaml
@@ -1,5 +1,7 @@
 range:
-  scan_range: 1.232.49.0/24
+  scan_ranges:
+    - 1.232.49.0/24
+  # - "2.16.37.0 2.16.37.255"  # Example of start/end format
   country_code: US
 
 user_agents:


### PR DESCRIPTION
## Summary
- allow specifying `scan_ranges` list in the configuration
- handle multiple ranges in `main.py`
- provide example `scan_ranges` usage in `settings.example.yaml`
- document new list format in README

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_6845a1691d0c83269c709fd5710d55ad