### PR TITLE
Include full range in output filenames

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ python main.py
 ```
 
 Results will be saved in the `results/` directory as CSV and JSON files.
+Output filenames now include the full scan range so each run writes to
+distinct files.
 
 ### Captured headers
 

--- a/main.py
+++ b/main.py
@@ -85,9 +85,9 @@ def run_scan_for_range(scan_range: str, country: str):
     # Iterate over either CIDR or explicit start/end IPs
     ip_iter = parse_scan_range(scan_range)
 
-    # Base name uses the starting IP of the range
-    ip_base = scan_range.split()[0].split("/")[0].replace(".", "_")
-    filename_id = f"{ip_base}_{country}"
+    # Use the full range string to build a unique identifier
+    range_id = scan_range.strip().replace("/", "_").replace(" ", "_")
+    filename_id = f"{range_id}_{country}"
     output_dir = "results"
     os.makedirs(output_dir, exist_ok=True)
     csv_file = os.path.join(output_dir, f"{filename_id}.csv")


### PR DESCRIPTION
## Summary
- encode the entire scan range into result filenames
- document filename changes in README

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_6845a2c9a70083268f7be8c4ce71ad3b